### PR TITLE
Added Morality and Conflict boxes

### DIFF
--- a/templates/parts/actor/ffg-tab-obligations.html
+++ b/templates/parts/actor/ffg-tab-obligations.html
@@ -67,6 +67,23 @@ actor.flags.starwarsffg.config.enableDuty true) )}}
 {{#if (or (eq actor.flags.starwarsffg.config.enableMorality undefined) (eq
 actor.flags.starwarsffg.config.enableMorality true) )}}
 <div class="block-editor gap">
+    {{> "modules/ffg-star-wars-alternative-ui/templates/parts/shared/ffg-block.html" (object
+    blocktype="single" title="SWFFG.DescriptionMorality" type="String" name="data.morality.value"
+    value=data.morality.value)}}
+</div>
+{{/if}}
+{{#if (or (eq actor.flags.starwarsffg.config.enableConflict undefined) (eq
+actor.flags.starwarsffg.config.enableConflict true) )}}
+<div class="block-editor gap">
+    {{> "modules/ffg-star-wars-alternative-ui/templates/parts/shared/ffg-block.html" (object
+    blocktype="single" title="SWFFG.DescriptionConflict" type="String" name="data.conflict.value"
+    value=data.conflict.value)}}
+</div>
+{{/if}}
+
+{{#if (or (eq actor.flags.starwarsffg.config.enableMorality undefined) (eq
+actor.flags.starwarsffg.config.enableMorality true) )}}
+<div class="block-editor gap">
     {{> "modules/ffg-star-wars-alternative-ui/templates/parts/shared/ffg-block.html" (object blocktype="full"
     title="SWFFG.EmotionalStrength" type="PopoutEditor" name="data.morality.strength"
     value=data.morality.strength)}}


### PR DESCRIPTION
In [ffg-tab-obligations.html](https://github.com/TeddyBears/StarWarsFFG-alternative-UI/blob/main/templates/parts/actor/ffg-tab-obligations.html), when using Morality on the character sheet the Emotional Strength and Emotional Weakness boxes both render but there are no boxes to show the Morality or Conflict values for the character.

This PR attempts to add those boxes based on code examples from this repo and from the [StarWarsFoundryVTT repo](https://github.com/StarWarsFoundryVTT/StarWarsFFG/blob/0c45a11d60020e4b287c9267dcf0d463b2a32cc7/templates/actors/ffg-character-sheet.html#L271).

Please do update with any desired styling changes or to fix any incorrect code. I'm hoping that the two boxes will end up displayed side-by-side, but I'm figuring this out as I go along.

This attempts to close #4 .